### PR TITLE
Update to pulse multiplier for accurate power data

### DIFF
--- a/esphome/components/emerald_ble/emerald_ble.h
+++ b/esphome/components/emerald_ble/emerald_ble.h
@@ -55,6 +55,7 @@ static const uint32_t RETURN_DEVICE_TIME_CMD =               0x0001010304;
 
 static const uint8_t standard_update_interval = 30;    // seconds
 static const float kw_to_w_conversion = 1000.0;    // conversion ratio
+static const float hr_to_s_conversion = 3600.0;    // conversion ratio
 
 
 class Emerald : public esphome::ble_client::BLEClientNode, public Component {
@@ -75,7 +76,7 @@ class Emerald : public esphome::ble_client::BLEClientNode, public Component {
 #endif
   void set_pulses_per_kwh(uint16_t pulses_per_kwh) {
     pulses_per_kwh_ = pulses_per_kwh;
-    pulse_multiplier_ = (standard_update_interval / (pulses_per_kwh / kw_to_w_conversion));
+    pulse_multiplier_ = ((hr_to_s_conversion * kw_to_w_conversion) / (standard_update_interval * pulses_per_kwh));
   }
   void set_pairing_code(uint32_t pairing_code) { pairing_code_ = pairing_code; }
 


### PR DESCRIPTION
Updated average power formula and included a conversion variable for hrs to s.

# What does this implement/fix?

This fix uses a new pulse multiplier formula to estimate power output, this results in a x4 increase in power output, but will be colser to the actual power output with an accuracy +/- 120 W (assuming a 1000 pulses/kWh). Ideally if the timestamps were known for each pulse (or the delta) we could increase this accuracy further. Pretty basic code change so hopefully I didn't break anything. Tested locally, but please verify on your own device using: 

```
external_components:
  - source: github://miragebird/esphome@emerald_ble_powerfix
```

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes WeekendWarrior1/emerald_electricity_advisor/issues/4

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```
external_components:
  - source: github://miragebird/esphome@emerald_ble_powerfix
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
