### PR TITLE
ESPHome 2022.11.0 compatibility

### DIFF
--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -92,12 +92,12 @@ void BLEClient::connect() {
   }
 }
 
-void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t esp_gattc_if,
+bool BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t esp_gattc_if,
                                     esp_ble_gattc_cb_param_t *param) {
   if (event == ESP_GATTC_REG_EVT && this->app_id != param->reg.app_id)
-    return;
+    return false;
   if (event != ESP_GATTC_REG_EVT && esp_gattc_if != ESP_GATT_IF_NONE && esp_gattc_if != this->gattc_if)
-    return;
+    return false;
 
   bool all_established = this->all_nodes_established_();
 
@@ -142,7 +142,7 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
     }
     case ESP_GATTC_DISCONNECT_EVT: {
       if (memcmp(param->disconnect.remote_bda, this->remote_bda, 6) != 0) {
-        return;
+        return false;
       }
       ESP_LOGV(TAG, "[%s] ESP_GATTC_DISCONNECT_EVT, reason %d", this->address_str().c_str(), param->disconnect.reason);
       for (auto &svc : this->services_)
@@ -204,6 +204,8 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
       delete svc;  // NOLINT(cppcoreguidelines-owning-memory)
     this->services_.clear();
   }
+
+  return true;
 }
 
 void BLEClient::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -86,7 +86,7 @@ class BLEClient : public espbt::ESPBTClient, public Component {
   void loop() override;
   float get_setup_priority() const override;
 
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+  bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
   bool parse_device(const espbt::ESPBTDevice &device) override;


### PR DESCRIPTION
# What does this implement/fix?

This PR aims to fix compilation issues after I upgraded to use ESPHome 2022.11.0:

```
--snip---
Compiling .pioenvs/power-pal/src/esphome/components/ble_client/ble_client.cpp.o
Compiling .pioenvs/power-pal/src/esphome/components/powerpal_ble/powerpal_ble.cpp.o
Compiling .pioenvs/power-pal/src/main.cpp.o
In file included from src/esphome/components/ble_client/ble_client.cpp:5:0:
src/esphome/components/ble_client/ble_client.h:89:8: error: conflicting return type specified for 'virtual void esphome::ble_client::BLEClient::gattc_event_handler(esp_gattc_cb_event_t, esp_gatt_if_t, esp_ble_gattc_cb_param_t*)'
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
        ^
In file included from src/esphome/components/ble_client/ble_client.cpp:4:0:
src/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h:162:16: error:   overriding 'virtual bool esphome::esp32_ble_tracker::ESPBTClient::gattc_event_handler(esp_gattc_cb_event_t, esp_gatt_if_t, esp_ble_gattc_cb_param_t*)'
   virtual bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                ^
In file included from src/esphome/components/powerpal_ble/powerpal_ble.h:4:0,
                 from src/esphome/components/powerpal_ble/powerpal_ble.cpp:1:
src/esphome/components/ble_client/ble_client.h:89:8: error: conflicting return type specified for 'virtual void esphome::ble_client::BLEClient::gattc_event_handler(esp_gattc_cb_event_t, esp_gatt_if_t, esp_ble_gattc_cb_param_t*)'
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
        ^
In file included from src/esphome/components/ble_client/ble_client.h:5:0,
                 from src/esphome/components/powerpal_ble/powerpal_ble.h:4,
                 from src/esphome/components/powerpal_ble/powerpal_ble.cpp:1:
src/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h:162:16: error:   overriding 'virtual bool esphome::esp32_ble_tracker::ESPBTClient::gattc_event_handler(esp_gattc_cb_event_t, esp_gatt_if_t, esp_ble_gattc_cb_param_t*)'
   virtual bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                ^
*** [.pioenvs/power-pal/src/esphome/components/powerpal_ble/powerpal_ble.cpp.o] Error 1
*** [.pioenvs/power-pal/src/esphome/components/ble_client/ble_client.cpp.o] Error 1
In file included from src/esphome/components/ble_client/automation.h:4:0,
                 from src/esphome.h:15,
                 from src/main.cpp:3:
src/esphome/components/ble_client/ble_client.h:89:8: error: conflicting return type specified for 'virtual void esphome::ble_client::BLEClient::gattc_event_handler(esp_gattc_cb_event_t, esp_gatt_if_t, esp_ble_gattc_cb_param_t*)'
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
        ^
In file included from src/esphome/components/ble_client/ble_client.h:5:0,
                 from src/esphome/components/ble_client/automation.h:4,
                 from src/esphome.h:15,
                 from src/main.cpp:3:
src/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h:162:16: error:   overriding 'virtual bool esphome::esp32_ble_tracker::ESPBTClient::gattc_event_handler(esp_gattc_cb_event_t, esp_gatt_if_t, esp_ble_gattc_cb_param_t*)'
   virtual bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                ^
*** [.pioenvs/power-pal/src/main.cpp.o] Error 1
--snip--
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
