### PR TITLE
#8 Fix compatibility with ESPHome 2023.6

### DIFF
--- a/esphome/components/emerald_ble/emerald_ble.cpp
+++ b/esphome/components/emerald_ble/emerald_ble.cpp
@@ -1,6 +1,7 @@
 #include "emerald_ble.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/time.h"
 
 #ifdef USE_ESP32
 
@@ -103,8 +104,8 @@ void Emerald::decode_emerald_packet_(const uint8_t *data, uint16_t length) {
           // else, use the emerald measurement timestamps
 #ifdef USE_TIME
           auto *time_ = *this->time_;
-          time::ESPTime date_of_measurement = time_->now();
-          // time::ESPTime date_of_measurement = this->time_->now();
+          ESPTime date_of_measurement = time_->now();
+          // ESPTime date_of_measurement = this->time_->now();
           if (date_of_measurement.is_valid()) {
             if (this->day_of_last_measurement_ == 0) { this->day_of_last_measurement_ = date_of_measurement.day_of_year; }
             else if (this->day_of_last_measurement_ != date_of_measurement.day_of_year) {


### PR DESCRIPTION
# What does this implement/fix?

Fixes compatibility issue with 202306.1 which breaks the  the time as in https://github.com/WeekendWarrior1/emerald_electricity_advisor/issues/8

```
external_components: 
  - source: github://gheydon/esphome@emerald_ble_powerfix 
```

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
