### PR TITLE
ESPHome compatibility fixes up to 2023.5.6

### DIFF
--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -92,12 +92,12 @@ void BLEClient::connect() {
   }
 }
 
-void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t esp_gattc_if,
+bool BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t esp_gattc_if,
                                     esp_ble_gattc_cb_param_t *param) {
   if (event == ESP_GATTC_REG_EVT && this->app_id != param->reg.app_id)
-    return;
+    return false;
   if (event != ESP_GATTC_REG_EVT && esp_gattc_if != ESP_GATT_IF_NONE && esp_gattc_if != this->gattc_if)
-    return;
+    return false;
 
   bool all_established = this->all_nodes_established_();
 
@@ -142,7 +142,7 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
     }
     case ESP_GATTC_DISCONNECT_EVT: {
       if (memcmp(param->disconnect.remote_bda, this->remote_bda, 6) != 0) {
-        return;
+        return false;
       }
       ESP_LOGV(TAG, "[%s] ESP_GATTC_DISCONNECT_EVT, reason %d", this->address_str().c_str(), param->disconnect.reason);
       for (auto &svc : this->services_)
@@ -204,6 +204,8 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
       delete svc;  // NOLINT(cppcoreguidelines-owning-memory)
     this->services_.clear();
   }
+
+	return true;
 }
 
 void BLEClient::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -86,7 +86,7 @@ class BLEClient : public espbt::ESPBTClient, public Component {
   void loop() override;
   float get_setup_priority() const override;
 
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+  bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
   bool parse_device(const espbt::ESPBTDevice &device) override;

--- a/esphome/components/powerpal_ble/powerpal_ble.cpp
+++ b/esphome/components/powerpal_ble/powerpal_ble.cpp
@@ -106,7 +106,7 @@ void Powerpal::parse_measurement_(const uint8_t *data, uint16_t length) {
       // else, use the powerpal measurement timestamps
 #ifdef USE_TIME
       auto *time_ = *this->time_;
-      time::ESPTime date_of_measurement = time_->now();
+      ESPTime date_of_measurement = time_->now();
       if (date_of_measurement.is_valid()) {
         if (this->day_of_last_measurement_ == 0) { this->day_of_last_measurement_ = date_of_measurement.day_of_year;}
         else if (this->day_of_last_measurement_ != date_of_measurement.day_of_year) {


### PR DESCRIPTION
# What does this implement/fix?

This PR implements the necessary fixes to allow ESPHome 2023.5.6 with this powerpal_ble component to compile.

@WeekendWarrior1 if you don't have the capacity to continue supporting this (very useful!) component, I'm happy to either:

- Work with the ESPHome folks to try and have the code merged in as an official component or
- I'm happy to take over as maintainer of the component?